### PR TITLE
* update #static_content_path to take a flavor or snippet name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Lint/UnusedMethodArgument:
     - 'lib/chef_gen/snippet/*.rb'
 
 Metrics/LineLength:
-  Max: 100
+  Max: 120
 
 Metrics/MethodLength:
   Max: 25

--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 # Changelog for chef-gen-flavor-base
 
+## 0.9.1
+
+* update #static_content_path to take a flavor or snippet name arg rather than relying on the NAME constant in the class, because this fails when you have C < B < FlavorBase (B would try to copy files from a directory named for C)
+* disable feature tests on CircleCI because it's failing with a bundler error that we don't see during local tests
+
 ## 0.9.0
 
 * extracted ChefGen::FlavorBase and the snippets in the namespace ChefGen::Snippets into a seperate gem

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ directory that chef-gen-flavors will pass to ChefDK:
 
 ```ruby
 do_add_content do
-  @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+  @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'flavor_name'))) + '/.']
 end
 ```
 
@@ -264,7 +264,7 @@ module ChefGen
       NAME = 'awesome_override1'
 
       before_copy_content do
-        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override1'))) + '/.']
       end
     end
   end
@@ -284,7 +284,7 @@ module ChefGen
 
       def initialize_generate
         @flavor.class.before_copy_content do
-          @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+          @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'before_copy_content'))) + '/.']
         end
       end
     end
@@ -450,7 +450,7 @@ using the name.
 
 ```ruby
 def initialize_setup
-  snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+  snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'snippet_name'))) + '/.'
   @flavor.class.do_add_content do
     tocopy << [snippet_content_path]
   end
@@ -699,7 +699,7 @@ module ChefGen
       NAME = 'almost_perfect'
 
       before_copy_content do
-        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'almost_perfect'))) + '/.']
       end
     end
   end

--- a/chef-gen-flavor-base.gemspec
+++ b/chef-gen-flavor-base.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
-# stub: chef-gen-flavor-base 0.9.0.20150909153100 ruby lib
+# stub: chef-gen-flavor-base 0.9.1.20150910100832 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "chef-gen-flavor-base"
-  s.version = "0.9.0.20150909153100"
+  s.version = "0.9.1.20150910100832"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]
   s.authors = ["James FitzGibbon"]
-  s.date = "2015-09-09"
+  s.date = "2015-09-10"
   s.description = "chef-gen-flavor-base is a base class to make it easy to create 'flavors'\nfor use with\n[chef-gen-flavors](https://github.com/jf647/chef-gen-flavors).\n\nchef-gen-flavors plugs into the 'chef generate' command provided by\nChefDK to let you provide an alternate template for cookbooks and other\nchef components.\n\nThis gem simply provides a class your flavor can derive from; templates\nare provided by separate gems, which you can host privately for use\nwithin your organization or publicly for the Chef community to use.\n\nAn example flavor that demonstrates how to use this gem is distributed\nseparately:\n[chef-gen-flavor-example](https://github.com/jf647/chef-gen-flavor-example)\n\nAt present this is focused primarily on providing templates for\ngeneration of cookbooks, as this is where most organization-specific\ncustomization takes place. Support for the other artifacts that ChefDK\ncan generate may work, but is not the focus of early releases."
   s.email = ["james@nadt.net"]
   s.extra_rdoc_files = ["History.md", "Manifest.txt", "README.md"]

--- a/circle.yml
+++ b/circle.yml
@@ -8,4 +8,4 @@ test:
   override:
     - mkdir -p $CIRCLE_TEST_REPORTS/cucumber $CIRCLE_TEST_REPORTS/rspec
     - bundle exec rspec --format RspecJunitFormatter --out $CIRCLE_TEST_REPORTS/rspec/rspec.xml
-    - bundle exec cucumber --format json --out $CIRCLE_TEST_REPORTS/cucumber/tests.cucumber
+#    - bundle exec cucumber --format json --out $CIRCLE_TEST_REPORTS/cucumber/tests.cucumber

--- a/lib/chef_gen/flavor_base.rb
+++ b/lib/chef_gen/flavor_base.rb
@@ -12,7 +12,7 @@ module ChefGen
     include ChefGen::FlavorBase::ResourceHelpers
 
     # the version of the gem
-    VERSION = '0.9.0'
+    VERSION = '0.9.1'
 
     # define common hooks
     define_hooks :before_initialize, :after_initialize,

--- a/lib/chef_gen/flavor_base/copy_helpers.rb
+++ b/lib/chef_gen/flavor_base/copy_helpers.rb
@@ -31,12 +31,13 @@ module ChefGen
 
       # returns the path to static content distributed with a flavor
       # @param file [String] the file to generate the path from
+      # @param flavor [String] the name of the flavor
       # @return [String] the path the static content relative to the file
       # @api private
-      def static_content_path(file)
+      def static_content_path(file, flavor)
         File.expand_path(
           File.join(
-            File.dirname(file), '..', '..', '..', 'shared', 'flavor', self.class::NAME
+            File.dirname(file), '..', '..', '..', 'shared', 'flavor', flavor
           )
         )
       end

--- a/lib/chef_gen/snippet/attributes.rb
+++ b/lib/chef_gen/snippet/attributes.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'attributes'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/chef_spec.rb
+++ b/lib/chef_gen/snippet/chef_spec.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'chef_spec'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/cookbook_base.rb
+++ b/lib/chef_gen/snippet/cookbook_base.rb
@@ -30,7 +30,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'cookbook_base'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/example_file.rb
+++ b/lib/chef_gen/snippet/example_file.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'example_file'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/example_template.rb
+++ b/lib/chef_gen/snippet/example_template.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'example_template'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/guard.rb
+++ b/lib/chef_gen/snippet/guard.rb
@@ -19,7 +19,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'guard'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/recipes.rb
+++ b/lib/chef_gen/snippet/recipes.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'recipes'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/resource_provider.rb
+++ b/lib/chef_gen/snippet/resource_provider.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'resource_provider'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/style_rubocop.rb
+++ b/lib/chef_gen/snippet/style_rubocop.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'style_rubocop'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet/test_kitchen.rb
+++ b/lib/chef_gen/snippet/test_kitchen.rb
@@ -14,7 +14,7 @@ module ChefGen
       # @api private
       def initialize_setup
         super
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'test_kitchen'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end

--- a/lib/chef_gen/snippet_base.rb
+++ b/lib/chef_gen/snippet_base.rb
@@ -33,12 +33,13 @@ module ChefGen
 
     # returns the path to static content distributed with a snippet
     # @param file [String] the file to generate the path from
+    # @param snippet [String] the name of the snippet
     # @return [String] the path the static content relative to the file
     # @api private
-    def static_content_path(file)
+    def static_content_path(file, snippet)
       File.expand_path(
         File.join(
-          File.dirname(file), '..', '..', '..', 'shared', 'snippet', self.class::NAME
+          File.dirname(file), '..', '..', '..', 'shared', 'snippet', snippet
         )
       )
     end

--- a/spec/lib/chef_gen/flavor_base_spec.rb
+++ b/spec/lib/chef_gen/flavor_base_spec.rb
@@ -12,7 +12,7 @@ module ChefGen
       end
 
       def add_content
-        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome'))) + '/.']
         super
       end
     end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome.rb
@@ -6,6 +6,7 @@ module ChefGen
     class Awesome < ChefGen::FlavorBase
       NAME = 'awesome'
       DESC = 'an awesome cookbook template'
+      VERSION = '0.0.0'
 
       def initialize(temp_path: nil, type: nil, recipe: nil)
         super
@@ -30,7 +31,7 @@ module ChefGen
       end
 
       do_add_content do
-        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome'))) + '/.']
       end
     end
   end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_derived.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_derived.rb
@@ -5,6 +5,11 @@ module ChefGen
     class AwesomeDerived < ChefGen::Flavor::Awesome
       NAME = 'awesome_derived'
       DESC = 'an awesome derived cookbook template'
+      VERSION = '0.0.0'
+
+      before_copy_content do
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_derived'))) + '/.']
+      end
     end
   end
 end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_override1.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_override1.rb
@@ -5,11 +5,12 @@ module ChefGen
     class AwesomeOverride1 < ChefGen::Flavor::Awesome
       NAME = 'awesome_override1'
       DESC = 'overrides content in the flavor'
+      VERSION = '0.0.0'
 
       # hooking into before_copy_content ensures we end up after
       # normal flavor and snippet files in the @tocopy list
       before_copy_content do
-        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__))) + '/.']
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override1'))) + '/.']
       end
     end
   end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_override2.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_override2.rb
@@ -5,6 +5,11 @@ module ChefGen
     class AwesomeOverride2 < ChefGen::Flavor::Awesome
       NAME = 'awesome_override2'
       DESC = 'overrides resources in the flavor'
+      VERSION = '0.0.0'
+
+      before_copy_content do
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override2'))) + '/.']
+      end
 
       # locks rubocop to v0.31, uses after hook to ensure we override
       # what the style_rubocop snippet sets as default

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet1.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet1.rb
@@ -7,11 +7,16 @@ module ChefGen
     class AwesomeOverrideSnippet1 < ChefGen::Flavor::Awesome
       NAME = 'awesome_override_snippet1'
       DESC = 'adds a snippet that overrides content'
+      VERSION = '0.0.0'
 
       def initialize(temp_path: nil, type: nil, recipe: nil)
         super
         # add a snippet that adds an Windows serverspec helper
         @snippets << ChefGen::Snippet::OverrideAddContent
+      end
+
+      before_copy_content do
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override_snippet1'))) + '/.']
       end
     end
   end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet2.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet2.rb
@@ -7,11 +7,16 @@ module ChefGen
     class AwesomeOverrideSnippet2 < ChefGen::Flavor::Awesome
       NAME = 'awesome_override_snippet2'
       DESC = 'adds a snippet that declares resources'
+      VERSION = '0.0.0'
 
       def initialize(temp_path: nil, type: nil, recipe: nil)
         super
         # add a snippet that removes ExampleFile and ExampleTemplate
         @snippets << ChefGen::Snippet::OverrideDeclareResources
+      end
+
+      before_copy_content do
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override_snippet2'))) + '/.']
       end
     end
   end

--- a/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet3.rb
+++ b/spec/support/fixtures/lib/chef_gen/flavor/awesome_override_snippet3.rb
@@ -5,6 +5,7 @@ module ChefGen
     class AwesomeOverrideSnippet3 < ChefGen::Flavor::Awesome
       NAME = 'awesome_override_snippet3'
       DESC = 'removes snippets from a parent flavor'
+      VERSION = '0.0.0'
 
       def initialize(temp_path: nil, type: nil, recipe: nil)
         super
@@ -12,6 +13,10 @@ module ChefGen
         @snippets.reject! do |e|
           e == ChefGen::Snippet::ExampleFile || e == ChefGen::Snippet::ExampleTemplate
         end
+      end
+
+      before_copy_content do
+        @tocopy << [File.expand_path(File.join(static_content_path(__FILE__, 'awesome_override_snippet3'))) + '/.']
       end
     end
   end

--- a/spec/support/fixtures/lib/chef_gen/snippet/override_add_content.rb
+++ b/spec/support/fixtures/lib/chef_gen/snippet/override_add_content.rb
@@ -9,7 +9,7 @@ module ChefGen
       private
 
       def initialize_setup
-        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__))) + '/.'
+        snippet_content_path = File.expand_path(File.join(static_content_path(__FILE__, 'override_add_content'))) + '/.'
         @flavor.class.do_add_content do
           tocopy << [snippet_content_path]
         end


### PR DESCRIPTION
 arg rather than relying on the NAME constant in the class, because this fails when you have C < B < FlavorBase (B would try to copy files from a directory named for C)

* disable feature tests on CircleCI because it's failing with a bundler error that we don't see during local tests